### PR TITLE
Bug fixes and text additions

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,10 @@ instructions, a scientific description of iCESM1.2 itself can be found online he
 
 https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2019MS001663
 
+or here:
+
+https://doi.org/10.1029/2019MS001663
+
 Finally, if you have any questions or concerns regarding this model then please add a post to the
 CESM forums:
 

--- a/README
+++ b/README
@@ -4,9 +4,15 @@
 
 iCESM1.2 is a version of NCAR's CESM1.2 with the ability to simulate water isotopes
 (HDO and H218O) through the entire modeled hydrologic cycle, along with the ability to simulate
-multiple different water tracers in the atmosphere (CAM5).  Instructions for running the model
-with water isotopes or water tracers can be found in the "instructions" directory included in this
-repository. Also, a scientific description of the model itself can be found online here:
+multiple different water tracers in the atmosphere (CAM5).  Please note that this version MUST
+run with water isotopes.  If you want a standard version of CESM1.2 then please find instructions
+for acquiring the non-isotopic CESM1.2 model online here:
+
+http://www.cesm.ucar.edu/models/cesm1.2/
+
+If you are interested in water isotopes or water tracers, then instructions for running iCESM1.2 with
+those tracers can be found in the "instructions" directory included in this repository. Along with those
+instructions, a scientific description of iCESM1.2 itself can be found online here:
 
 https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2019MS001663
 

--- a/instructions/water_isotopes/iclm4_IC_create.ncl
+++ b/instructions/water_isotopes/iclm4_IC_create.ncl
@@ -1,7 +1,7 @@
 ;iclm4_IC_create.ncl
 ;
 ;Goal:  To create an isotopic Initial Conditions (IC) file for iCLM4.  The file is needed not only to allow the model to run
-;properly, but it can also grealy help the spin-up of deep snow pack and soil water.
+;properly, but it can also greatly help the spin-up of deep snow pack and soil water.
 ;
 ;Written by:  Jesse Nusbaumer <nusbaume@colorado.edu> - June, 2014.
 ;
@@ -20,8 +20,8 @@ begin
 Rstd = 1.0  ;Standard ratio used to convert from delta values to water masses.
 
 ;isotope delta values:
-ifilo = "/glade/p/work/nusbaume/isotope_obs/GNIP/d18o.2x2.ltm.nc"
-ifild = "/glade/p/work/nusbaume/isotope_obs/GNIP/hdo.2x2.ltm.nc"
+ifilo = "./d18o.2x2.ltm.nc"
+ifild = "./hdo.2x2.ltm.nc"
 
 ;CLM4 IC file:
 
@@ -29,10 +29,10 @@ ifild = "/glade/p/work/nusbaume/isotope_obs/GNIP/hdo.2x2.ltm.nc"
 cdir = "/glade/p/work/nusbaume/inputdata/clm4/"
 
 ;0.5x.0.5:
-cfil = "clmi.BCN.2000-01-01_0.47x0.63_gx1v6_simyr2000_c121030.nc"
+;cfil = "clmi.BCN.2000-01-01_0.47x0.63_gx1v6_simyr2000_c121030.nc"
 
 ;1x1:
-;cfil = "clmi.BCN.2000-01-01_0.9x1.25_gx1v6_simyr2000_c100303.nc"
+cfil = "clmi.BCN.2000-01-01_0.9x1.25_gx1v6_simyr2000_c100303.nc"
 
 ;2x2:
 ;cfil = "clmi.BCN.2000-01-01_1.9x2.5_gx1v6_simyr2000_c100309.nc"
@@ -48,6 +48,9 @@ cfil = "clmi.BCN.2000-01-01_0.47x0.63_gx1v6_simyr2000_c121030.nc"
 
 ;2x2 - 850:
 ;cfil = "b.e11.B1850C5CN.f19_g16.0850cntl.001.clm2.r.0850-01-01-00000.nc"
+
+;file output directory (location where you want new IC file written):
+odir = "./"
 
 ;********************
 ;Read in CLM4 IC file
@@ -73,7 +76,7 @@ lonp = cin->pfts1d_lon ;longitudes per pft
 ;**************************************
 
 oin = addfile(ifilo,"r") ;open netCDF files
-din = addfile(ifild,"r") 
+din = addfile(ifild,"r")
 
 d18o = oin->d18o         ;read in variables
 dDo  = din->hdo
@@ -117,7 +120,7 @@ print(min(R18))
 ;Find closest column/pft locations
 ;*********************************
 
-;NOTE: Using the nearest coordinate method may result 
+;NOTE: Using the nearest coordinate method may result
 ;in the loss of data, given that an individual point
 ;is used to represent the grid cell, instead of an
 ;interpolated average.  However, for now this is probably
@@ -309,8 +312,8 @@ do c = 0,dimsizes(h2osno)-1 ;loop over columns
   wt_hdo(c) = wt(c)*RD(ilat_col(c),ilon_col(c))
 
   ;GNIP ratios:
-  Rgnip_o18(c) = R18(ilat_col(c),ilon_col(c))
-  Rgnip_hdo(c) = RD(ilat_col(c),ilon_col(c)) 
+  Rgnip_o18(c) = (/ R18(ilat_col(c),ilon_col(c)) /)
+  Rgnip_hdo(c) = (/ RD(ilat_col(c),ilon_col(c)) /)
 
   ;2-D variables:
   
@@ -333,64 +336,64 @@ do p = 0,dimsizes(h2ocan)-1 ;loop over PFTs
   h2ocan_hdo(p) = h2ocan(p)*RD(ilat_pft(p),ilon_pft(p))
 
   ;Canopy isotopic vapor ratio:
-  Rcan_o18(p)   = R18(ilat_pft(p),ilon_pft(p))
-  Rcan_hdo(p)   = RD(ilat_pft(p),ilon_pft(p))
+  Rcan_o18(p)   = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rcan_hdo(p)   = (/ RD(ilat_pft(p),ilon_pft(p))  /)
 
   ;Sun isotopic leaf water ratio:
-  Rsun_o18(p)   = R18(ilat_pft(p),ilon_pft(p))
-  Rsun_hdo(p)   = RD(ilat_pft(p),ilon_pft(p))
+  Rsun_o18(p)   = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rsun_hdo(p)   = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Shade isotopic leaf water ratio:
-  Rsha_o18(p)   = R18(ilat_pft(p),ilon_pft(p))
-  Rsha_hdo(p)   = RD(ilat_pft(p),ilon_pft(p))
+  Rsha_o18(p)   = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rsha_hdo(p)   = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Isotopic ratio of sun leaf produced cellulose:
-  Rsncl_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rsncl_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))
+  Rsncl_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rsncl_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p))  /)
 
   ;Isotopic ratio of shade leaf produced cellulose:
-  Rshcl_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rshcl_hdo(p)  = RD(ilat_pft(p),ilon_pft(p)) 
+  Rshcl_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rshcl_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Isotopic ratio of sun cellulose * photosynthesis:
-  Rsnclp_o18(p) = R18(ilat_pft(p),ilon_pft(p))
-  Rsnclp_hdo(p) = RD(ilat_pft(p),ilon_pft(p))
+  Rsnclp_o18(p) = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rsnclp_hdo(p) = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Isotopic ratio of shade cellulose * photosynthesis:
-  Rshclp_o18(p) = R18(ilat_pft(p),ilon_pft(p))
-  Rshclp_hdo(p) = RD(ilat_pft(p),ilon_pft(p))
+  Rshclp_o18(p) = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rshclp_hdo(p) = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Peclet effect - included sunlit leaf ratios (diagnostic only):
-  Rsndg_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rsndg_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))
+  Rsndg_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rsndg_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Peclet effect - included shaded leaf ratios (diagnostic only):
-  Rshdg_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rshdg_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))   
+  Rshdg_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rshdg_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p))  /)
 
   ;steady-state sunlit leaf ratios:
-  Rsnss_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rsnss_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))
+  Rsnss_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rsnss_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;steady-state shaded leaf ratios:
-  Rshss_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rshss_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))
+  Rshss_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rshss_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;steady-state sunlit leaf ratios * photosynthesis:
-  Rsnssp_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rsnssp_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))
+  Rsnssp_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rsnssp_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;steady-state shaded leaf ratios * photosynthesis:
-  Rshssp_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rshssp_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))
+  Rshssp_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rshssp_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Isotopic ratio of Xylem water:
-  Rxym_o18(p)   = R18(ilat_pft(p),ilon_pft(p))
-  Rxym_hdo(p)   = RD(ilat_pft(p),ilon_pft(p))
+  Rxym_o18(p)   = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rxym_hdo(p)   = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
   ;Isotopic canopy liquid water ratio:
-  Rcnwt_o18(p)  = R18(ilat_pft(p),ilon_pft(p))
-  Rcnwt_hdo(p)  = RD(ilat_pft(p),ilon_pft(p))
+  Rcnwt_o18(p)  = (/ R18(ilat_pft(p),ilon_pft(p)) /)
+  Rcnwt_hdo(p)  = (/ RD(ilat_pft(p),ilon_pft(p)) /)
 
 end do
 
@@ -534,7 +537,7 @@ Rgnip_h2o@units      = "unitless"
 Rgnip_o18@long_name  = "H218O GNIP isotope ratio"
 Rgnip_o18@units      = "unitless"
 Rgnip_hdo@long_name  = "HDO GNIP isotope ratio"
-Rgnip_hdo@units      = "unitless"  
+Rgnip_hdo@units      = "unitless"
 
 h2ocan_h2o@long_name = "H2OTR canopy water"
 h2ocan_h2o@units     = "kg/m2"
@@ -669,11 +672,9 @@ h2oice_hdo@units     = "kg/m2"
 ;********************
 
 ;temporary file:
-tfil = "/glade/p/work/nusbaume/iso_clm4_IC.nc"
+tfil = "./iso_clm4_IC.nc"
 
-system("rm -f "+tfil)      ;remove old file
-
-out = addfile("/glade/p/work/nusbaume/iso_clm4_IC.nc","c") ;create new netCDF file
+out = addfile(tfil,"c") ;create new netCDF file
 
 ;Snow water:
 out->H2OSNO_H2OTR = h2osno_h2o
@@ -789,9 +790,6 @@ out->Rcanopywater_H218O = Rcnwt_o18
 ;Combine netCDF files together
 ;*****************************
 
-;file output directory:
-odir = "/glade/p/work/nusbaume/inputdata/isotopic_inputdata/clm4/GNIP_based/"
-
 ;Copy over base CLM4 file:
 system("cp "+cdir+cfil+" "+odir+cfil)
 
@@ -800,6 +798,9 @@ system("chmod u+w "+odir+cfil)
 
 ;Add isotopic variables to file:
 system("ncks -A "+tfil+" "+odir+cfil)
+
+;Remove temporary file:
+system("rm -f "+tfil)
 
 ;***********
 ;End program

--- a/instructions/water_isotopes/water_isotope_instructions.txt
+++ b/instructions/water_isotopes/water_isotope_instructions.txt
@@ -1,6 +1,6 @@
 How to setup a CESM simulation with water isotopes:
 
-1.  Create new case (i.e. run iCESM1.2/scripts/create_newcase).       
+1.  Create new case (i.e. run iCESM1.2/scripts/create_newcase).
 
 2.  Add "-water_tracer h2o_h216o_hdo_h218o" to CAM_CONFIG_OPTS in env_build.xml
 
@@ -8,14 +8,19 @@ How to setup a CESM simulation with water isotopes:
 
 4.  Run cesm_setup
 
-5.  Add the line:
+5.  If doing a pre-industrial simulation and wanting a spun-up simulation off which to start a hybrid or branch run, then
+    you can download iCESM1.2 restart files online here:
+
+    https://doi.org/10.5281/zenodo.3553753
+
+5.  Otherwise, if doing a startup run, then add the line:
 
     finidat = '<yourpath>/<isotopic_clm4_IC_file>'
 
     to user_nl_clm, where <yourpath> is the path to wherever an isotopic iCLM4 initial conditions netCDF file is kept.  Please note that
-    this file is resolution and time-period dependent, so if a particular file doesn't work for your simulation then you will need to generate 
+    this file is resolution and time-period dependent, so if a particular file doesn't work for your simulation then you will need to generate
     a new one.  This can be done using the "iclm4_IC_create.ncl" script, which will generate an isotopic copy of a standard "finidat" file.
-    Please note that the NCL script requires two netCDF files, which should be included in this tarball (d180.2x2.ltm.nc and hdo.2x2.ltm.nc). 
+    Please note that the NCL script requires two netCDF files, which should be included in this directory (d180.2x2.ltm.nc and hdo.2x2.ltm.nc).
 
 6.  Add the line "tr_iso = .true." to user_nl_cice.
 

--- a/instructions/water_tags/example_water_tracers/atm_comp_mct.F90
+++ b/instructions/water_tags/example_water_tracers/atm_comp_mct.F90
@@ -746,7 +746,7 @@ CONTAINS
     !water isotopes:
     real(r8) :: R  !water tracer ratio
 
-   real(r8)           :: wtlat
+    real(r8)           :: wtlat
     real(r8)           :: wtlon
     real(r8), parameter:: radtodeg = 180.0_r8/SHR_CONST_PI
 

--- a/instructions/water_tags/example_water_tracers/user_nl_cam
+++ b/instructions/water_tags/example_water_tracers/user_nl_cam
@@ -9,12 +9,6 @@
 !Water tags:
  wtrc_names             = 'H2OV', 'H2OL', 'H2OI', 'H2OR', 'H2OS', 'H2Or', 'H2Os', 'H216OV', 'H216OL', 'H216OI','H216OR','H216OS','H216Or',
    'H216Os','HDOV','HDOL', 'HDOI', 'HDOR', 'HDOS', 'HDOr', 'HDOs', 'H218OV', 'H218OL', 'H218OI', 'H218OR', 'H218OS', 'H218Or', 'H218Os',
-   'LNDV', 'LNDL', 'LNDI', 'LNDR', 'LNDS', 'LNDr', 'LNDs', 'ARCV', 'ARCL', 'ARCI', 'ARCR', 'ARCS', 'ARCr', 'ARCs', 'NPAV', 'NPAL',
-   'NPAI', 'NPAR', 'NPAS', 'NPAr', 'NPAs', 'NATV', 'NATL', 'NATI', 'NATR', 'NATS', 'NATr', 'NATs', 'SNPV', 'SNPL', 'SNPI', 'SNPR',
-   'SNPS', 'SNPr', 'SNPs', 'GOMV', 'GOML', 'GOMI', 'GOMR', 'GOMS', 'GOMr', 'GOMs', 'SNAV', 'SNAL', 'SNAI', 'SNAR', 'SNAS', 'SNAr', 'SNAs',
-   'EQIV', 'EQIL', 'EQII', 'EQIR', 'EQIS', 'EQIr', 'EQIs', 'WRMV', 'WRML', 'WRMI', 'WRMR', 'WRMS', 'WRMr', 'WRMs', 'EQPV', 'EQPL', 'EQPI',
-   'EQPR', 'EQPS', 'EQPr', 'EQPs', 'SBIV', 'SBIL', 'SBII', 'SBIR', 'SBIS', 'SBIr', 'SBIs', 'SPAV', 'SPAL', 'SPAI', 'SPAR', 'SPAS', 'SPAr',
-   'SPAs', 'SATV', 'SATL', 'SATI', 'SATR', 'SATS', 'SATr', 'SATs', 'SOCNV', 'SOCNL', 'SOCNI', 'SOCNR', 'SOCNS', 'SOCNr', 'SOCNs', 
    'LNDV', 'LNDL', 'LNDI', 'LNDR', 'LNDS', 'LNDr', 'LNDs', 'NPACV', 'NPACL', 'NPACI', 'NPACR', 'NPACS', 'NPACr', 'NPACs'
 
  wtrc_species_names             = 'H2O', 'H2O', 'H2O', 'H2O', 'H2O', 'H2O', 'H2O', 'H216O', 'H216O', 'H216O', 'H216O', 'H216O', 'H216O',

--- a/models/ocn/pop2/source/wiso_mod.F90
+++ b/models/ocn/pop2/source/wiso_mod.F90
@@ -1855,8 +1855,8 @@ character(*), parameter :: sub_name = 'wiso_mod:wiso_init'
    WISO_SFLUX_18O(:,:,:) = WISO_SFLUX_18O(:,:,:) - avg_18O_F + avg_16O_F
    WISO_SFLUX_HDO(:,:,:) = WISO_SFLUX_HDO(:,:,:) - avg_HDO_F + avg_16O_F
 
-   WISO_SFLUX_TAVG(:,:,37,:) = (WISO_SFLUX_18O - WISO_SFLUX_16O) * fwmass_to_fwflux
-   WISO_SFLUX_TAVG(:,:,38,:) = (WISO_SFLUX_HDO - WISO_SFLUX_16O) * fwmass_to_fwflux
+   WISO_SFLUX_TAVG(:,:,37,:) = (WISO_SFLUX_18O - WISO_SFLUX_16O) * fwmass_to_fwflux * c1000
+   WISO_SFLUX_TAVG(:,:,38,:) = (WISO_SFLUX_HDO - WISO_SFLUX_16O) * fwmass_to_fwflux * c1000
 
 !-----------------------------------------------------------------------
 !  do marginal sea balancing before setting the STF array

--- a/scripts/ccsm_utils/Tools/cesm_postrun_setup
+++ b/scripts/ccsm_utils/Tools/cesm_postrun_setup
@@ -44,7 +44,7 @@ cd $CASEROOT
 if ($DOUT_S == 'TRUE') then
   echo "Archiving cesm output to $DOUT_S_ROOT"
   echo "Calling the short-term archiving script st_archive.sh"
-  cd $RUNDIR; $CASETOOLS/st_archive.sh
+  cd $RUNDIR; $CASETOOLS/st_archive.sh; cd $CASEROOT
 endif
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds additional bug fixes provided by Jiang Zhu. 

Along with the bug fixes themselves, additional edits were made to the README file and water isotope instructions text file to try and provide additional clarity and information to potential users.  These modifications were also suggested by Jiang Zhu.

Finally, modified the iCLM4 isotopic initial conditions NCL script to improve usability and prevent un-necessary warning messages.

Files added:  N/A

Files modified:

wiso_mod.F90  ->  Fixed unit conversion bug.

cesm_postrun_setup -> Fixed local directory bug.

README ->  Added text informing potential users that this version has to run with water isotopes, and provided a link to the original CESM1.2 model in case users are looking for that version instead.  Also added a doi link to the iCESM1 JAMES manuscript.

water_isotope_instructions.txt -> Added a link to the iCESM1.2 restart files zenodo repository, and a description of when a user might want to use these files.

iclm4_IC_create.ncl ->  Updated file paths to improve usability, and updated file copying routines to prevent needless NCL warning messages.

Files removed:  N/A

Tests run:

Smoke test - A B1850 compset was run on Cheyenne with water isotopes for five time steps, using the Intel compiler and a "start-up" configuration.

Script test - Ran iclm4_IC_create.ncl on an apple laptop with NCL version 6.6.2 to ensure the updated script works appropriately.  